### PR TITLE
Fix inline comment in example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Flags:
 
 [Server]
   host = "irc.freenode.net"
-  port = "6697" // Common NON-SSL Port 6667
+  port = "6697" # Common NON-SSL Port 6667
   ssl = true
   insecure = false
   nick = "Komanda"


### PR DESCRIPTION
The config as written doesn't parse:

```
FATA[0000] error loading configuration file - Near line 7 (last key parsed 'Server'): Expected a top-level item to end with a new line, comment or EOF, but got '/' instead.
```